### PR TITLE
在 .devcontainer 中安装 x86_64 版本 buck2 

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -10,7 +10,7 @@
   "dockerFile": "Dockerfile",
   "settings": {
     "editor.formatOnSave": true,
-    "terminal.integrated.shell.linux": "/usr/bin/zsh",
+    "terminal.integrated.shell.linux": "/usr/bin/bash",
     "files.exclude": {
       "**/CODE_OF_CONDUCT.md": true,
       "**/LICENSE": true

--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -46,6 +46,8 @@ chown -R $USER_UID:$USER_GID /home/$USERNAME/.oh-my-zsh /home/$USERNAME/.zshrc
 ## Install Buck2
 wget https://github.com/facebook/buck2/releases/download/2025-02-01/buck2-x86_64-unknown-linux-musl.zst /home/$USERNAME/buck2-x86_64-unknown-linux-musl.zst
 zstd -d /home/$USERNAME/buck2-x86_64-unknown-linux-musl.zst
-mv /home/$USERNAME/buck2-x86_64-unknown-linux-musl /home/$USERNAME/buck2
-chomod +x /home/$USERNAME/buck2
-mv /home/$USERNAME/buck2 /usr/local/bin
+mkdir -p /home/$USERNAME/.buck/bin
+mv /home/$USERNAME/buck2-x86_64-unknown-linux-musl /home/$USERNAME/.buck/bin/buck2
+chmod +x /home/$USERNAME/.buck/bin/buck2
+chown -R $USER_UID:$USER_GID /home/$USERNAME/.buck
+export PATH="/home/$USERNAME/.buck2/bin:$PATH"

--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -36,18 +36,9 @@ rustup component add clippy
 cargo install cargo-expand
 cargo install cargo-edit
 
-## Setup and install oh-my-zsh
-sh -c "$(curl -fsSL https://raw.githubusercontent.com/robbyrussell/oh-my-zsh/master/tools/install.sh)"
-cp -R /root/.oh-my-zsh /home/$USERNAME
-cp /root/.zshrc /home/$USERNAME
-sed -i -e "s/\/root\/.oh-my-zsh/\/home\/$USERNAME\/.oh-my-zsh/g" /home/$USERNAME/.zshrc
-chown -R $USER_UID:$USER_GID /home/$USERNAME/.oh-my-zsh /home/$USERNAME/.zshrc
-
 ## Install Buck2
-wget https://github.com/facebook/buck2/releases/download/2025-02-01/buck2-x86_64-unknown-linux-musl.zst /home/$USERNAME/buck2-x86_64-unknown-linux-musl.zst
-zstd -d /home/$USERNAME/buck2-x86_64-unknown-linux-musl.zst
-mkdir -p /home/$USERNAME/.buck/bin
-mv /home/$USERNAME/buck2-x86_64-unknown-linux-musl /home/$USERNAME/.buck/bin/buck2
-chmod +x /home/$USERNAME/.buck/bin/buck2
-chown -R $USER_UID:$USER_GID /home/$USERNAME/.buck
-export PATH="/home/$USERNAME/.buck2/bin:$PATH"
+wget https://github.com/facebook/buck2/releases/download/2025-02-01/buck2-x86_64-unknown-linux-musl.zst /root/buck2-x86_64-unknown-linux-musl.zst
+zstd -d /root/buck2-x86_64-unknown-linux-musl.zst
+mv /root/buck2-x86_64-unknown-linux-musl /root/buck2
+chmod +x /root/buck2
+mv /root/buck2 /usr/local/bin/buck2

--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -31,8 +31,6 @@ cargo install cargo-edit
 
 ## Install Buck2
 wget https://github.com/facebook/buck2/releases/download/2025-02-01/buck2-x86_64-unknown-linux-musl.zst
-pwd
-ls
 zstd -d /home/buck2-x86_64-unknown-linux-musl.zst
 mv /home/buck2-x86_64-unknown-linux-musl /home/buck2
 chmod +x /home/buck2

--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -24,7 +24,8 @@ apt-get install -y \
   libgtk-3-dev \
   libayatana-appindicator3-dev \
   librsvg2-dev \
-  ca-certificates
+  ca-certificates \
+  zstd
 
 ## Install rustup and common components
 curl https://sh.rustup.rs -sSf | sh -s -- -y
@@ -41,3 +42,10 @@ cp -R /root/.oh-my-zsh /home/$USERNAME
 cp /root/.zshrc /home/$USERNAME
 sed -i -e "s/\/root\/.oh-my-zsh/\/home\/$USERNAME\/.oh-my-zsh/g" /home/$USERNAME/.zshrc
 chown -R $USER_UID:$USER_GID /home/$USERNAME/.oh-my-zsh /home/$USERNAME/.zshrc
+
+## Install Buck2
+wget https://github.com/facebook/buck2/releases/download/2025-02-01/buck2-x86_64-unknown-linux-musl.zst /home/$USERNAME/buck2-x86_64-unknown-linux-musl.zst
+zstd -d /home/$USERNAME/buck2-x86_64-unknown-linux-musl.zst
+mv /home/$USERNAME/buck2-x86_64-unknown-linux-musl /home/$USERNAME/buck2
+chomod +x /home/$USERNAME/buck2
+mv /home/$USERNAME/buck2 /usr/local/bin

--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -37,8 +37,9 @@ cargo install cargo-expand
 cargo install cargo-edit
 
 ## Install Buck2
-wget https://github.com/facebook/buck2/releases/download/2025-02-01/buck2-x86_64-unknown-linux-musl.zst /root/buck2-x86_64-unknown-linux-musl.zst
-zstd -d /root/buck2-x86_64-unknown-linux-musl.zst
-mv /root/buck2-x86_64-unknown-linux-musl /root/buck2
-chmod +x /root/buck2
-mv /root/buck2 /usr/local/bin/buck2
+wget https://github.com/facebook/buck2/releases/download/2025-02-01/buck2-x86_64-unknown-linux-musl.zst
+pwd
+zstd -d buck2-x86_64-unknown-linux-musl.zst
+mv /root/buck2-x86_64-unknown-linux-musl buck2
+chmod +x buck2
+mv buck2 /usr/local/bin/buck2

--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -7,23 +7,16 @@ apt-get install -y \
   jq \
   sudo \
   zsh \
-  vim \
   build-essential \
   openssl \
   libssl-dev \
   fuse3 \
   libfuse3-dev \
   pkg-config \
-  postgresql \
   cmake \
   clang \
-  nodejs \
-  npm \
   wget \
   file \
-  libgtk-3-dev \
-  libayatana-appindicator3-dev \
-  librsvg2-dev \
   ca-certificates \
   zstd
 
@@ -39,7 +32,8 @@ cargo install cargo-edit
 ## Install Buck2
 wget https://github.com/facebook/buck2/releases/download/2025-02-01/buck2-x86_64-unknown-linux-musl.zst
 pwd
-zstd -d buck2-x86_64-unknown-linux-musl.zst
-mv /root/buck2-x86_64-unknown-linux-musl buck2
-chmod +x buck2
-mv buck2 /usr/local/bin/buck2
+ls
+zstd -d /home/buck2-x86_64-unknown-linux-musl.zst
+mv /home/buck2-x86_64-unknown-linux-musl /home/buck2
+chmod +x /home/buck2
+mv /home/buck2 /usr/local/bin/buck2


### PR DESCRIPTION
1. 在 `.devcontainer` 中安装 `buck2`，开发者可以在 Codespace 中直接使用 `buck2` 进行开发测试；
2. 移除目前项目构建过程中不需要的一些 Library