### PR TITLE
Add experimental support for self-hosted runner in base workflow

### DIFF
--- a/.github/workflows/base.yml
+++ b/.github/workflows/base.yml
@@ -14,67 +14,9 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  setup:
-    strategy:
-      fail-fast: false
-
-    name: Setup and cache
-    runs-on: ubuntu-latest
-
-    env:
-      CARGO_TERM_COLOR: always
-
-    steps:
-      - name: Restore cache
-        id: cache-restore
-        uses: actions/cache/restore@v4
-        with:
-          path: |
-            /home/runner/.cargo/bin/buck2
-            /home/runner/.cargo/bin/reindeer
-          key: buck2-binary
-
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          submodules: recursive
-
-      - name: Setup Rust Toolchain
-        uses: actions-rust-lang/setup-rust-toolchain@v1
-        with:
-          components: clippy rustfmt
-          cache-workspaces: |
-            ./project
-          cache-directories: |
-            ./project/target
-
-      - name: Install Buck2
-        if: ${{ steps.cache-restore.outputs.cache-hit != 'true' }}
-        run: |
-          curl https://github.com/facebook/buck2/releases/download/latest/buck2-x86_64-unknown-linux-gnu.zst --output "${{runner.temp}}/buck2-x86_64-unknown-linux-gnu.zst" --location --silent --show-error --fail --retry 5
-          zstd -d "${{runner.temp}}/buck2-x86_64-unknown-linux-gnu.zst" -o $HOME/.cargo/bin/buck2
-          chmod +x $HOME/.cargo/bin/buck2
-          rm -f "${{runner.temp}}/buck2-x86_64-unknown-linux-gnu.zst"
-        shell: bash
-      
-      - name: Install Reindeer
-        if: ${{ steps.cache-restore.outputs.cache-hit != 'true' }}
-        run: cargo install --locked --git https://github.com/facebookincubator/reindeer reindeer
-        shell: bash
-
-      - name: Save cache
-        if: ${{ steps.cache-restore.outputs.cache-hit != 'true' }}
-        uses: actions/cache/save@v4
-        with:
-          path: |
-            /home/runner/.cargo/bin/buck2
-            /home/runner/.cargo/bin/reindeer
-          key: buck2-binary
-
   format:
     name: Rustfmt Check
-    runs-on: ubuntu-latest
-    needs: setup
+    runs-on: [self-hosted]
 
     env:
       CARGO_TERM_COLOR: always
@@ -95,8 +37,7 @@ jobs:
     strategy:
       fail-fast: true
 
-    runs-on: ubuntu-latest
-    needs: setup
+    runs-on: [self-hosted]
     env:
       CARGO_TERM_COLOR: always
 
@@ -106,9 +47,6 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Install system dependencies
-        uses: ./.github/install-sys-deps
-
       - name: Run cargo clippy
         run: |
           cd project
@@ -117,17 +55,13 @@ jobs:
   build:
     name: Buck2 Build
 
-    runs-on: ubuntu-latest
-    needs: setup
+    runs-on: [self-hosted]
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           submodules: recursive
-
-      - name: Install system dependencies
-        uses: ./.github/install-sys-deps
 
       - name: Build with Buck2
         run: |
@@ -138,17 +72,13 @@ jobs:
   test:
     name: Buck2 Test
 
-    runs-on: ubuntu-latest
-    needs: setup
+    runs-on: [self-hosted]
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           submodules: recursive
-
-      - name: Install system dependencies
-        uses: ./.github/install-sys-deps
 
       - name: Run tests with Buck2
         run: echo "Running tests with Buck2 ..."


### PR DESCRIPTION
在工作流配置文件中为 https://github.com/r2cn-dev/rk8s/issues/52 添加试验性支持，验证 self-hosted runner 环境配置

已知问题：
- 目前 self-hosted runner 以单机单实例的方式配置，直接在物理机环境中运行工作流，可能存在安全问题
- 单机单实例的配置方式可能导致作业无法并发运行，浪费物理机器硬件资源

https://github.com/r2cn-dev/rk8s/issues/52 具体实现方案：
- 基于 [actions/actions-runner-controller](https://github.com/actions/actions-runner-controller) 搭建 self-hosted runner 弹性集合
- 自定义 runner 镜像避免重复搭建环境
- 自托管物理机器上搭建 Buck2 共享缓存，加快工作流中构建、测试速度