### PR TITLE
Add pre-commit-hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,17 @@
+repos:
+-   repo: local
+    hooks:
+    -   id: rust-linting
+        name: Rust linting
+        description: Run cargo fmt on files included in the commit.
+        entry: cargo fmt --manifest-path project/Cargo.toml --all --check --
+        pass_filenames: false
+        types: [file, rust]
+        language: system
+    -   id: rust-clippy
+        name: Rust clippy
+        description: Run cargo clippy on files included in the commit.
+        entry: cargo clippy --manifest-path project/Cargo.toml --workspace -- -D warnings
+        pass_filenames: false
+        types: [file, rust]
+        language: system


### PR DESCRIPTION
为 rk8s 增加了 git pre-commit hook

在每次 commit 之前执行 `cargo fmt` 和 `cargo clippy`，命令的配置与 GitHub workflow 中的配置保持一致

您需要先安装 pre-commit（参考[链接](https://pre-commit.com/#install)），然后在项目根目录下执行 `pre-commit install` 安装钩子