### PR TITLE
adjust code structure of rks and init cli

### DIFF
--- a/project/rks/BUCK
+++ b/project/rks/BUCK
@@ -16,6 +16,7 @@ rust_binary(
         "//third-party:anyhow",
         "//third-party:rcgen",
         "//third-party:etcd-client",
+        "//third-party:clap",
     ],
     env = {
         "CARGO_PKG_AUTHORS": "r2cn-dev team",

--- a/project/rks/Cargo.toml
+++ b/project/rks/Cargo.toml
@@ -6,8 +6,9 @@ edition = "2024"
 [dependencies]
 tokio = { version = "1.44", features = ["full"] }
 serde = { version = "1.0", features = ["derive"] }
-rustls = "0.23"
+clap = { version = "4.5.32", features = ["derive"] }
 quinn = { version = "0.11.8" }
+rustls = "0.23"
 serde_yaml = "0.9"
 bincode = "1.3.3"         
 futures = "0.3.31"       

--- a/project/rks/src/cli.rs
+++ b/project/rks/src/cli.rs
@@ -1,0 +1,18 @@
+use clap::{Parser, Subcommand};
+use std::path::PathBuf;
+
+#[derive(Parser)]
+#[command(name = "rks", version, about = "RKS daemon CLI")]
+pub struct Cli {
+    #[command(subcommand)]
+    pub command: Commands,
+}
+
+#[derive(Subcommand)]
+pub enum Commands {
+    /// Start the RKS daemon with config file
+    Start {
+        #[arg(short, long)]
+        config: PathBuf,
+    },
+}

--- a/project/rks/src/commands/create.rs
+++ b/project/rks/src/commands/create.rs
@@ -1,0 +1,67 @@
+use crate::api::xlinestore::XlineStore;
+use crate::protocol::{PodTask, RksMessage};
+use anyhow::Result;
+use quinn::Connection;
+use std::sync::Arc;
+use tokio::sync::broadcast;
+
+pub async fn watch_create(pod_task: &PodTask, conn: &Connection, node_id: &str) -> Result<()> {
+    if pod_task.nodename == node_id {
+        let msg = RksMessage::CreatePod(Box::new(pod_task.clone()));
+        let data = bincode::serialize(&msg)?;
+        if let Ok(mut stream) = conn.open_uni().await {
+            stream.write_all(&data).await?;
+            stream.finish()?;
+            println!(
+                "[watch_pods] send CreatePod for pod: {} to node: {}",
+                pod_task.metadata.name, node_id
+            );
+        }
+    }
+    Ok(())
+}
+
+pub async fn user_create(
+    mut pod_task: Box<PodTask>,
+    xline_store: &Arc<XlineStore>,
+    conn: &Connection,
+    tx: &broadcast::Sender<RksMessage>,
+) -> Result<()> {
+    if let Ok(nodes) = xline_store.list_nodes().await {
+        if let Some((node_name, _)) = nodes.first() {
+            pod_task.nodename = node_name.clone();
+            let pod_yaml = match serde_yaml::to_string(&pod_task) {
+                Ok(yaml) => yaml,
+                Err(e) => {
+                    eprintln!("[user dispatch] Failed to serialize pod task: {}", e);
+                    let response = RksMessage::Error(format!("Serialization error: {}", e));
+                    let data = bincode::serialize(&response).unwrap_or_else(|_| vec![]);
+                    if let Ok(mut stream) = conn.open_uni().await {
+                        stream.write_all(&data).await?;
+                        stream.finish()?;
+                    }
+                    return Ok(());
+                }
+            };
+
+            xline_store
+                .insert_pod_yaml(&pod_task.metadata.name, &pod_yaml)
+                .await?;
+
+            println!(
+                "[user dispatch] created pod: {}, assigned to node: {}",
+                pod_task.metadata.name, node_name
+            );
+
+            let _ = tx.send(RksMessage::CreatePod(pod_task.clone()));
+
+            let response = RksMessage::Ack;
+            let data = bincode::serialize(&response)?;
+            if let Ok(mut stream) = conn.open_uni().await {
+                stream.write_all(&data).await?;
+                stream.finish()?;
+            }
+        }
+    }
+    Ok(())
+}

--- a/project/rks/src/commands/delete.rs
+++ b/project/rks/src/commands/delete.rs
@@ -1,0 +1,52 @@
+use crate::api::xlinestore::XlineStore;
+use crate::protocol::{PodTask, RksMessage};
+use anyhow::Result;
+use quinn::Connection;
+use std::sync::Arc;
+use tokio::sync::broadcast;
+
+pub async fn watch_delete(
+    pod_name: String,
+    conn: &Connection,
+    xline_store: &Arc<XlineStore>,
+    node_id: &str,
+) -> Result<()> {
+    let msg = RksMessage::DeletePod(pod_name.clone());
+    if let Ok(pods) = xline_store.list_pods().await {
+        for p in pods {
+            if let Ok(Some(pod_yaml)) = xline_store.get_pod_yaml(&p).await {
+                let pod_task: PodTask = serde_yaml::from_str(&pod_yaml)
+                    .map_err(|e| anyhow::anyhow!("Failed to parse pod_yaml: {}", e))?;
+                if pod_task.nodename == node_id && pod_task.metadata.name == pod_name {
+                    let data = bincode::serialize(&msg)?;
+                    if let Ok(mut stream) = conn.open_uni().await {
+                        stream.write_all(&data).await?;
+                        stream.finish()?;
+                    }
+                    break;
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+pub async fn user_delete(
+    pod_name: String,
+    xline_store: &Arc<XlineStore>,
+    conn: &Connection,
+    tx: &broadcast::Sender<RksMessage>,
+) -> Result<()> {
+    let _ = xline_store.delete_pod(&pod_name).await;
+    println!("[user dispatch] deleted pod: {}", pod_name);
+
+    let _ = tx.send(RksMessage::DeletePod(pod_name.clone()));
+
+    let response = RksMessage::Ack;
+    let data = bincode::serialize(&response)?;
+    if let Ok(mut stream) = conn.open_uni().await {
+        stream.write_all(&data).await?;
+        stream.finish()?;
+    }
+    Ok(())
+}

--- a/project/rks/src/commands/mod.rs
+++ b/project/rks/src/commands/mod.rs
@@ -1,0 +1,2 @@
+pub mod create;
+pub mod delete;

--- a/project/rks/src/main.rs
+++ b/project/rks/src/main.rs
@@ -1,24 +1,28 @@
 mod api;
+mod cli;
+mod commands;
 mod protocol;
 mod server;
 use api::xlinestore::XlineStore;
-use protocol::config::{Config, load_config};
+use clap::Parser;
+use cli::{Cli, Commands};
+use protocol::config::load_config;
 use server::serve;
-use std::env;
 use std::sync::Arc;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    let config_path = env::var("RKS_CONFIG_PATH").unwrap_or_else(|_| {
-        format!(
-            "{}/tests/config.yaml",
-            std::env::var("CARGO_MANIFEST_DIR").unwrap()
-        )
-    });
-    let cfg: Config = load_config(&config_path)?;
-    let endpoints: Vec<&str> = cfg.xline_endpoints.iter().map(|s| s.as_str()).collect();
-    let xline_store = Arc::new(XlineStore::new(&endpoints).await?);
-    println!("[rks] listening on {}", cfg.addr);
-    serve(cfg.addr, xline_store).await?;
+    let cli = Cli::parse();
+
+    match &cli.command {
+        Commands::Start { config } => {
+            let cfg = load_config(config.to_str().unwrap())?;
+            let endpoints: Vec<&str> = cfg.xline_endpoints.iter().map(|s| s.as_str()).collect();
+            let xline_store = Arc::new(XlineStore::new(&endpoints).await?);
+            println!("[rks] listening on {}", cfg.addr);
+            serve(cfg.addr, xline_store).await?;
+        }
+    }
+
     Ok(())
 }

--- a/project/rks/src/protocol/mod.rs
+++ b/project/rks/src/protocol/mod.rs
@@ -86,16 +86,23 @@ pub struct PodTask {
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub enum RksMessage {
+    //request
     CreatePod(Box<PodTask>),
     DeletePod(String),
     GetNodeCount,
     RegisterNode(String),
     UserRequest(String),
-}
+    Heartbeat(String),
 
-#[derive(Debug, Serialize, Deserialize, Clone)]
-pub enum RksResponse {
+    //response
     Ack,
     Error(String),
     NodeCount(usize),
 }
+
+// #[derive(Debug, Serialize, Deserialize, Clone)]
+// pub enum RksResponse {
+//     Ack,
+//     Error(String),
+//     NodeCount(usize),
+// }


### PR DESCRIPTION
1.为rks实现命令行，目前提供start命令，用于传入配置文件路径来启动rks。
2.创建commands文件夹，增加create,delete模块。将server.rs中Podcreate，Poddelete的消息处理逻辑移至对应模块中。
3.统一用单向流进行传输，修改server.rs中dispatch_worker的处理逻辑，应该用于处理来自工作节点RKL的反馈信息。