### PR TITLE
feat(rks): integrate libscheduler into rks

### DIFF
--- a/BUCK
+++ b/BUCK
@@ -13,6 +13,7 @@ rust_binary(
         "root//project/libfuse-fs:libfuse-fs",
         "root//project/libipam:libipam",
         "root//project/libnetwork:libnetwork",
+        "root//project/libscheduler:libscheduler",
         "root//project/rkb:rkb",
         "root//project/rks:rks",
         "root//project/rkl:rkl_bin",

--- a/project/libscheduler/BUCK
+++ b/project/libscheduler/BUCK
@@ -1,0 +1,28 @@
+rust_library(
+    name = "libscheduler",
+    srcs = glob(
+        ["src/**/*.rs"],
+    ),
+    edition = "2024",
+    deps = [
+      "//third-party:anyhow",
+      "//third-party:etcd-client",
+      "//third-party:serde",
+      "//third-party:serde_yaml",
+      "//third-party:tokio",
+      "//third-party:uuid",
+      "//third-party:log",
+      "//third-party:bitflags",
+    ],
+    env = {
+        "CARGO_PKG_AUTHORS": "r2cn-dev team",
+        "CARGO_PKG_DESCRIPTION": "Scheduler library for rk8s",
+        "CARGO_PKG_NAME": "libscheduler",
+        "CARGO_PKG_REPOSITORY": "https://github.com/r2cn-dev/rk8s/tree/main/project/libscheduler",
+        "CARGO_PKG_VERSION": "0.1.0",
+        "CARGO_PKG_VERSION_MAJOR": "0",
+        "CARGO_PKG_VERSION_MINOR": "1",
+        "CARGO_PKG_VERSION_PATCH": "0",
+    },
+    visibility = ["PUBLIC"],
+)

--- a/project/libscheduler/BUCK
+++ b/project/libscheduler/BUCK
@@ -3,6 +3,7 @@ rust_library(
     srcs = glob(
         ["src/**/*.rs"],
     ),
+    crate_root = "src/lib.rs",
     edition = "2024",
     deps = [
       "//third-party:anyhow",

--- a/project/libscheduler/BUCK
+++ b/project/libscheduler/BUCK
@@ -15,6 +15,7 @@ rust_library(
       "//third-party:uuid",
       "//third-party:log",
       "//third-party:bitflags",
+      "//project/common:common",
     ],
     env = {
         "CARGO_PKG_AUTHORS": "r2cn-dev team",

--- a/project/libscheduler/BUCK
+++ b/project/libscheduler/BUCK
@@ -9,6 +9,7 @@ rust_library(
       "//third-party:etcd-client",
       "//third-party:serde",
       "//third-party:serde_yaml",
+      "//third-party:serial_test",
       "//third-party:tokio",
       "//third-party:uuid",
       "//third-party:log",

--- a/project/libscheduler/Cargo.toml
+++ b/project/libscheduler/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
+common = { path = "../common" }
 anyhow = "1.0.98"
 bitflags = "2.9.2"
 etcd-client = "0.16.1"

--- a/project/libscheduler/src/plugins/balanced_allocation.rs
+++ b/project/libscheduler/src/plugins/balanced_allocation.rs
@@ -60,18 +60,14 @@ fn is_schedulable_after_pod_event(pod: PodInfo, event: EventInner) -> Result<Que
     match event {
         EventInner::Pod(_original, modified) => {
             if modified.is_none() {
-                log::trace!(
-                    "pod was deleted, may make unscheduled pod schedulable. pod {:?}",
-                    pod
-                );
+                log::trace!("pod was deleted, may make unscheduled pod schedulable. pod {pod:?}");
                 Ok(QueueingHint::Queue)
             } else {
                 Ok(QueueingHint::Skip)
             }
         }
         _ => Err(format!(
-            "event inner {:?} not match event resource pod",
-            event
+            "event inner {event:?} not match event resource pod"
         )),
     }
 }
@@ -86,31 +82,24 @@ fn is_schedulable_after_node_change(
             if is_fit(&pod_requests, &modified) {
                 if original.is_none() {
                     log::trace!(
-                        "node was added and fits pod resource requests. pod {:?} node {:?}",
-                        pod,
-                        modified
+                        "node was added and fits pod resource requests. pod {pod:?} node {modified:?}"
                     );
                     Ok(QueueingHint::Queue)
                 } else {
                     log::trace!(
-                        "node was updated and fits pod resource requests. pod {:?} node {:?}",
-                        pod,
-                        modified
+                        "node was updated and fits pod resource requests. pod {pod:?} node {modified:?}"
                     );
                     Ok(QueueingHint::Queue)
                 }
             } else {
                 log::trace!(
-                    "node was created or updated, but doesn't have enough resources. pod {:?} node {:?}",
-                    pod,
-                    modified
+                    "node was created or updated, but doesn't have enough resources. pod {pod:?} node {modified:?}"
                 );
                 Ok(QueueingHint::Skip)
             }
         }
         _ => Err(format!(
-            "event inner {:?} not match event resource node",
-            event
+            "event inner {event:?} not match event resource node"
         )),
     }
 }
@@ -143,10 +132,7 @@ impl PreScorePlugin for BalancedAllocation {
         let pod_requests = pod.spec.resources.clone();
 
         if self.is_best_effort_pod(&pod_requests) {
-            log::trace!(
-                "Skipping BalancedAllocation scoring for best-effort pod {:?}",
-                pod
-            );
+            log::trace!("Skipping BalancedAllocation scoring for best-effort pod {pod:?}");
             return Status::new(Code::Skip, vec![]);
         }
 

--- a/project/libscheduler/src/plugins/node_affinity.rs
+++ b/project/libscheduler/src/plugins/node_affinity.rs
@@ -36,8 +36,7 @@ fn is_schedulable_after_node_change(
 ) -> Result<QueueingHint, String> {
     match event {
         EventInner::Pod(_, _) => Err(format!(
-            "event inner {:?} not match event resource node",
-            event
+            "event inner {event:?} not match event resource node"
         )),
         EventInner::Node(original, modeified) => {
             // Differ to kubernetes, we don't have scheduler-enforced affinity now
@@ -48,32 +47,24 @@ fn is_schedulable_after_node_change(
                 if let Some(old) = *original {
                     if required_node_affinity.matches(&old) {
                         log::trace!(
-                            "node updated, but the pod's NodeAffinity hasn't changed. pod {:?} node {:?}",
-                            pod,
-                            modeified
+                            "node updated, but the pod's NodeAffinity hasn't changed. pod {pod:?} node {modeified:?}"
                         );
                         Ok(QueueingHint::Skip)
                     } else {
                         log::trace!(
-                            "node was updated and the pod's NodeAffinity changed to matched. pod {:?} node {:?}",
-                            pod,
-                            modeified
+                            "node was updated and the pod's NodeAffinity changed to matched. pod {pod:?} node {modeified:?}"
                         );
                         Ok(QueueingHint::Queue)
                     }
                 } else {
                     log::trace!(
-                        "node was created, and matches with the pod's NodeAffinity. pod {:?} node {:?}",
-                        pod,
-                        modeified
+                        "node was created, and matches with the pod's NodeAffinity. pod {pod:?} node {modeified:?}"
                     );
                     Ok(QueueingHint::Queue)
                 }
             } else {
                 log::trace!(
-                    "node was created or updated, but the pod's NodeAffinity doesn't match. pod {:?} node {:?}",
-                    pod,
-                    modeified
+                    "node was created or updated, but the pod's NodeAffinity doesn't match. pod {pod:?} node {modeified:?}"
                 );
                 Ok(QueueingHint::Skip)
             }

--- a/project/libscheduler/src/plugins/node_resources_fit.rs
+++ b/project/libscheduler/src/plugins/node_resources_fit.rs
@@ -56,18 +56,14 @@ fn is_schedulable_after_pod_event(pod: PodInfo, event: EventInner) -> Result<Que
     match event {
         EventInner::Pod(_original, modified) => {
             if modified.is_none() {
-                log::trace!(
-                    "pod was deleted, may make unscheduled pod schedulable. pod {:?}",
-                    pod
-                );
+                log::trace!("pod was deleted, may make unscheduled pod schedulable. pod {pod:?}");
                 Ok(QueueingHint::Queue)
             } else {
                 Ok(QueueingHint::Skip)
             }
         }
         _ => Err(format!(
-            "event inner {:?} not match event resource pod",
-            event
+            "event inner {event:?} not match event resource pod"
         )),
     }
 }
@@ -82,31 +78,24 @@ fn is_schedulable_after_node_change(
             if is_fit(&pod_requests, &modified) {
                 if original.is_none() {
                     log::trace!(
-                        "node was added and fits pod resource requests. pod {:?} node {:?}",
-                        pod,
-                        modified
+                        "node was added and fits pod resource requests. pod {pod:?} node {modified:?}"
                     );
                     Ok(QueueingHint::Queue)
                 } else {
                     log::trace!(
-                        "node was updated and fits pod resource requests. pod {:?} node {:?}",
-                        pod,
-                        modified
+                        "node was updated and fits pod resource requests. pod {pod:?} node {modified:?}"
                     );
                     Ok(QueueingHint::Queue)
                 }
             } else {
                 log::trace!(
-                    "node was created or updated, but doesn't have enough resources. pod {:?} node {:?}",
-                    pod,
-                    modified
+                    "node was created or updated, but doesn't have enough resources. pod {pod:?} node {modified:?}"
                 );
                 Ok(QueueingHint::Skip)
             }
         }
         _ => Err(format!(
-            "event inner {:?} not match event resource node",
-            event
+            "event inner {event:?} not match event resource node"
         )),
     }
 }

--- a/project/libscheduler/src/plugins/taint_toleration.rs
+++ b/project/libscheduler/src/plugins/taint_toleration.rs
@@ -134,8 +134,7 @@ fn is_schedulable_after_node_change(
 ) -> Result<QueueingHint, String> {
     match event {
         EventInner::Pod(_, _) => Err(format!(
-            "event inner {:?} not match event resource node",
-            event
+            "event inner {event:?} not match event resource node"
         )),
         EventInner::Node(old, new) => {
             let was_untolerated = old.is_none()
@@ -150,16 +149,12 @@ fn is_schedulable_after_node_change(
                 .is_some();
             if was_untolerated && !is_untolerated {
                 log::trace!(
-                    "node was created or updated, and this may make the Pod rejected by TaintToleration plugin in the previous scheduling cycle schedulable. node {:?}, pod: {:?}",
-                    new,
-                    pod
+                    "node was created or updated, and this may make the Pod rejected by TaintToleration plugin in the previous scheduling cycle schedulable. node {new:?}, pod: {pod:?}"
                 );
                 Ok(QueueingHint::Queue)
             } else {
                 log::trace!(
-                    "node was created or updated, but it doesn't change the TaintToleration plugin's decision node {:?}, pod: {:?}",
-                    new,
-                    pod
+                    "node was created or updated, but it doesn't change the TaintToleration plugin's decision node {new:?}, pod: {pod:?}"
                 );
                 Ok(QueueingHint::Skip)
             }
@@ -173,14 +168,12 @@ fn is_schedulable_after_pod_toleration_change(
 ) -> Result<QueueingHint, String> {
     match event {
         EventInner::Node(_, _) => Err(format!(
-            "event inner {:?} not match event resource pod",
-            event
+            "event inner {event:?} not match event resource pod"
         )),
         EventInner::Pod(_old, new) => {
             if new.is_some() && new.unwrap().name == pod.name {
                 log::trace!(
-                    "a new toleration is added for the unschedulable Pod, and it may make it schedulable. pod {:?}",
-                    pod
+                    "a new toleration is added for the unschedulable Pod, and it may make it schedulable. pod {pod:?}"
                 );
                 Ok(QueueingHint::Queue)
             } else {

--- a/project/libscheduler/src/with_xline/model.rs
+++ b/project/libscheduler/src/with_xline/model.rs
@@ -26,6 +26,9 @@ fn default_namespace() -> String {
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct PodSpec {
+    //if pod is distributed to a node ,then this field should be filled with node-id
+    #[serde(default)]
+    pub nodename: Option<String>,
     #[serde(default)]
     pub containers: Vec<ContainerSpec>,
     #[serde(default)]
@@ -78,8 +81,6 @@ pub struct PodTask {
     pub kind: String,
     pub metadata: ObjectMeta,
     pub spec: PodSpec,
-    //if pod is distributed to a node ,then this field should be filled with node-id
-    pub nodename: String,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]

--- a/project/libscheduler/src/with_xline/utils.rs
+++ b/project/libscheduler/src/with_xline/utils.rs
@@ -2,10 +2,8 @@ use std::collections::HashMap;
 
 use etcd_client::{Client, GetOptions, KeyValue};
 
-use crate::{
-    models::{NodeInfo, NodeSpec, PodInfo, PodSpec, QueuedInfo, ResourcesRequirements},
-    with_xline::model::{Node, PodTask},
-};
+use crate::models::{NodeInfo, NodeSpec, PodInfo, PodSpec, QueuedInfo, ResourcesRequirements};
+use common::{Node, PodTask};
 
 pub async fn get_pod(
     client: &mut Client,
@@ -101,7 +99,7 @@ fn convert_pod_task_to_pod_info(pod_task: PodTask) -> PodInfo {
         priority: 0,
         scheduling_gates: Vec::new(),
         tolerations: Vec::new(),
-        node_name: pod_task.spec.nodename.clone(),
+        node_name: pod_task.spec.node_name.clone(),
         node_selector: HashMap::new(),
         affinity: None,
     };
@@ -110,7 +108,7 @@ fn convert_pod_task_to_pod_info(pod_task: PodTask) -> PodInfo {
         name: pod_task.metadata.name,
         spec,
         queued_info: QueuedInfo::default(),
-        scheduled: pod_task.spec.nodename.clone(),
+        scheduled: pod_task.spec.node_name.clone(),
     }
 }
 

--- a/project/libscheduler/src/with_xline/utils.rs
+++ b/project/libscheduler/src/with_xline/utils.rs
@@ -101,11 +101,7 @@ fn convert_pod_task_to_pod_info(pod_task: PodTask) -> PodInfo {
         priority: 0,
         scheduling_gates: Vec::new(),
         tolerations: Vec::new(),
-        node_name: if pod_task.nodename.is_empty() {
-            None
-        } else {
-            Some(pod_task.nodename.clone())
-        },
+        node_name: pod_task.spec.nodename.clone(),
         node_selector: HashMap::new(),
         affinity: None,
     };
@@ -114,11 +110,7 @@ fn convert_pod_task_to_pod_info(pod_task: PodTask) -> PodInfo {
         name: pod_task.metadata.name,
         spec,
         queued_info: QueuedInfo::default(),
-        scheduled: if pod_task.nodename.is_empty() {
-            None
-        } else {
-            Some(pod_task.nodename)
-        },
+        scheduled: pod_task.spec.nodename.clone(),
     }
 }
 

--- a/project/libscheduler/tests/xline_test.rs
+++ b/project/libscheduler/tests/xline_test.rs
@@ -127,6 +127,7 @@ fn create_test_pod(name: &str, cpu_limit: Option<&str>, memory_limit: Option<&st
             annotations: HashMap::new(),
         },
         spec: XlinePodSpec {
+            nodename: None,
             containers: vec![ContainerSpec {
                 name: "app".to_string(),
                 image: "nginx:latest".to_string(),
@@ -136,7 +137,6 @@ fn create_test_pod(name: &str, cpu_limit: Option<&str>, memory_limit: Option<&st
             }],
             init_containers: vec![],
         },
-        nodename: "".to_string(),
     }
 }
 
@@ -482,7 +482,7 @@ async fn test_scheduler_with_xline_existing_assignment() {
         .expect("Failed to put node");
 
     let mut assigned_pod = create_test_pod("already-assigned", Some("1"), Some("1Gi"));
-    assigned_pod.nodename = "existing-node".to_string();
+    assigned_pod.spec.nodename = Some("existing-node".to_string());
     etcd_client
         .put_pod(&assigned_pod)
         .await

--- a/project/libscheduler/tests/xline_test.rs
+++ b/project/libscheduler/tests/xline_test.rs
@@ -4,13 +4,13 @@ use std::time::Duration;
 use tokio::sync::mpsc;
 use tokio::time::timeout;
 
-use etcd_client::{Client, DeleteOptions};
-use libscheduler::plugins::Plugins;
-use libscheduler::plugins::node_resources_fit::ScoringStrategy;
-use libscheduler::with_xline::model::{
+use common::{
     ContainerRes, ContainerSpec, Node, NodeAddress, NodeCondition, NodeSpec as XlineNodeSpec,
     NodeStatus, ObjectMeta, PodSpec as XlinePodSpec, PodTask, Resource,
 };
+use etcd_client::{Client, DeleteOptions};
+use libscheduler::plugins::Plugins;
+use libscheduler::plugins::node_resources_fit::ScoringStrategy;
 use libscheduler::with_xline::run_scheduler_with_xline;
 
 const ETCD_ENDPOINTS: &[&str] = &["127.0.0.1:2379"];
@@ -127,7 +127,7 @@ fn create_test_pod(name: &str, cpu_limit: Option<&str>, memory_limit: Option<&st
             annotations: HashMap::new(),
         },
         spec: XlinePodSpec {
-            nodename: None,
+            node_name: None,
             containers: vec![ContainerSpec {
                 name: "app".to_string(),
                 image: "nginx:latest".to_string(),
@@ -482,7 +482,7 @@ async fn test_scheduler_with_xline_existing_assignment() {
         .expect("Failed to put node");
 
     let mut assigned_pod = create_test_pod("already-assigned", Some("1"), Some("1Gi"));
-    assigned_pod.spec.nodename = Some("existing-node".to_string());
+    assigned_pod.spec.node_name = Some("existing-node".to_string());
     etcd_client
         .put_pod(&assigned_pod)
         .await

--- a/project/rks/BUCK
+++ b/project/rks/BUCK
@@ -37,6 +37,7 @@ rust_binary(
         "//third-party:tokio-util",
         "//third-party:once_cell",
         "//third-party:env_logger",
+        "//third-party:serial_test",
         "//project/libcni:libcni",
         "//project/common:common",
         "//project/libscheduler:libscheduler"

--- a/project/rks/BUCK
+++ b/project/rks/BUCK
@@ -39,6 +39,7 @@ rust_binary(
         "//third-party:env_logger",
         "//project/libcni:libcni",
         "//project/common:common",
+        "//project/libscheduler:libscheduler"
     ],
     linker_flags = [
         "-lssl",

--- a/project/rks/Cargo.toml
+++ b/project/rks/Cargo.toml
@@ -38,3 +38,6 @@ tempfile = "3.20.0"
 tokio-util = "0.7.0"
 env_logger = "0.11.0"
 once_cell = "1.21.0"
+
+[dev-dependencies]
+serial_test = "3.2.0"

--- a/project/rks/Cargo.toml
+++ b/project/rks/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2024"
 [dependencies]
 common = { path = "../common" }
 libcni = { path = "../libcni" }
+libscheduler = { path = "../libscheduler" }
 tokio = { version = "1.44", features = ["full"] }
 serde = { version = "1.0", features = ["derive"] }
 clap = { version = "4.5.32", features = ["derive"] }

--- a/project/rks/src/api/xlinestore.rs
+++ b/project/rks/src/api/xlinestore.rs
@@ -1,3 +1,4 @@
+#![allow(dead_code)]
 use anyhow::Result;
 use common::Node;
 use etcd_client::{Client, GetOptions, PutOptions};
@@ -91,10 +92,11 @@ impl XlineStore {
         client.delete(key, None).await?;
         Ok(())
     }
-    // pub async fn delete_node(&self, node_name: &str) -> Result<()> {
-    //     let key = format!("/registry/nodes/{}", node_name);
-    //     let mut client = self.client.write().await;
-    //     client.delete(key, None).await?;
-    //     Ok(())
-    // }
+
+    pub async fn delete_node(&self, node_name: &str) -> Result<()> {
+        let key = format!("/registry/nodes/{node_name}");
+        let mut client = self.client.write().await;
+        client.delete(key, None).await?;
+        Ok(())
+    }
 }

--- a/project/rks/src/lib.rs
+++ b/project/rks/src/lib.rs
@@ -1,3 +1,4 @@
 pub mod api;
 pub mod network;
 pub mod protocol;
+pub mod scheduler;

--- a/project/rks/src/main.rs
+++ b/project/rks/src/main.rs
@@ -3,12 +3,12 @@ mod cli;
 mod commands;
 mod network;
 mod protocol;
-mod server;
 mod scheduler;
+mod server;
 
-use crate::{api::xlinestore::XlineStore, scheduler::Scheduler};
 use crate::network::init;
 use crate::protocol::config::load_config;
+use crate::{api::xlinestore::XlineStore, scheduler::Scheduler};
 use anyhow::Context;
 use clap::Parser;
 use cli::{Cli, Commands};

--- a/project/rks/src/main.rs
+++ b/project/rks/src/main.rs
@@ -6,7 +6,7 @@ mod protocol;
 mod server;
 mod scheduler;
 
-use crate::{api:: xlinestore::XlineStore, scheduler::Scheduler};
+use crate::{api::xlinestore::XlineStore, scheduler::Scheduler};
 use crate::network::init;
 use crate::protocol::config::load_config;
 use anyhow::Context;

--- a/project/rks/src/scheduler.rs
+++ b/project/rks/src/scheduler.rs
@@ -48,7 +48,7 @@ impl Scheduler {
     pub async fn run(mut self) {
         tokio::spawn(async move {
             loop {
-                // if get an assigmnent from the scheduler, then modify the pod spec 's node_name and save to xline store
+                // if get an assignment from the scheduler, then modify the pod spec 's node_name and save to xline store
                 if let Some(Ok(assignment)) = self.assignment_rx.recv().await
                     && let Ok(Some(pod_yaml)) =
                         self.xline_store.get_pod_yaml(&assignment.pod_name).await
@@ -59,9 +59,9 @@ impl Scheduler {
                             serde_yaml::to_string(&pod_task)
                         });
 
-                    if yaml.is_ok() {
+                    if let Ok(yaml_string) = yaml {
                         let _ = self.xline_store
-                            .insert_pod_yaml(&assignment.pod_name, &yaml.unwrap())
+                            .insert_pod_yaml(&assignment.pod_name, &yaml_string)
                             .await;
                     }
                 }

--- a/project/rks/src/scheduler.rs
+++ b/project/rks/src/scheduler.rs
@@ -1,0 +1,71 @@
+use std::sync::Arc;
+
+use anyhow::Result;
+use common::PodTask;
+use libscheduler::{
+    models::Assignment,
+    plugins::{Plugins, node_resources_fit::ScoringStrategy},
+    with_xline::run_scheduler_with_xline,
+};
+use tokio::sync::mpsc;
+
+use crate::api::xlinestore::XlineStore;
+
+pub struct Scheduler {
+    assignment_rx: mpsc::UnboundedReceiver<Result<Assignment, anyhow::Error>>,
+    xline_store: Arc<XlineStore>,
+}
+
+impl Scheduler {
+    pub async fn try_new(
+        xline_endpoints: &[&str],
+        xline_store: Arc<XlineStore>,
+        scoring_strategy: ScoringStrategy,
+        plugins: Plugins,
+    ) -> Result<Self> {
+        let (_unassume_tx, unassume_rx) = mpsc::unbounded_channel();
+        let assignment_rx = run_scheduler_with_xline(
+            xline_endpoints,
+            scoring_strategy,
+            plugins,
+            unassume_rx,
+        )
+        .await?;
+
+        Ok(Self {
+            assignment_rx,
+            xline_store,
+        })
+    }
+
+    /// Runs the scheduler's main loop to process pod assignments.
+    ///
+    /// Spawns a background task that continuously:
+    /// - Receives pod assignments from the scheduler
+    /// - Updates the pod's node assignment in the xline store
+    ///
+    /// Returns immediately after spawning the background task.
+    pub async fn run(mut self) {
+        tokio::spawn(async move {
+            loop {
+                // if get an assigmnent from the scheduler, then modify the pod spec 's node_name and save to xline store
+                if let Some(Ok(assignment)) = self.assignment_rx.recv().await
+                    && let Ok(Some(pod_yaml)) =
+                        self.xline_store.get_pod_yaml(&assignment.pod_name).await
+                {
+                    let yaml =
+                        serde_yaml::from_str::<PodTask>(&pod_yaml).and_then(|mut pod_task| {
+                            pod_task.spec.nodename = Some(assignment.node_name);
+                            serde_yaml::to_string(&pod_task)
+                        });
+
+                    if yaml.is_ok() {
+                        let _ = self.xline_store
+                            .insert_pod_yaml(&assignment.pod_name, &yaml.unwrap())
+                            .await;
+                    }
+                }
+            }
+        });
+    }
+}

--- a/project/rks/src/server.rs
+++ b/project/rks/src/server.rs
@@ -411,7 +411,7 @@ pub async fn dispatch_user(
 
         RksMessage::ListPod => {
             let pods = xline_store.list_pods().await?;
-            println!("[user dispatch] list current pod: {:?}", pods);
+            println!("[user dispatch] list current pod: {pods:?}");
             let res = bincode::serialize(&RksMessage::ListPodRes(pods))?;
             if let Ok(mut stream) = conn.open_uni().await {
                 stream.write_all(&res).await?;

--- a/project/rks/tests/test_scheduler.rs
+++ b/project/rks/tests/test_scheduler.rs
@@ -1,0 +1,337 @@
+use serial_test::serial;
+use common::{
+    ContainerRes, ContainerSpec, Node, NodeAddress, NodeCondition, NodeSpec, NodeStatus,
+    ObjectMeta, PodSpec, PodTask, Resource,
+};
+use libscheduler::plugins::{Plugins, node_resources_fit::ScoringStrategy};
+use std::{collections::HashMap, sync::Arc};
+
+use anyhow::Result;
+use rks::protocol::config::load_config;
+use rks::{api::xlinestore::XlineStore, scheduler::Scheduler};
+
+// Get xline endpoints from config
+fn get_xline_endpoints() -> Vec<String> {
+    let config_path = std::env::var("TEST_CONFIG_PATH").unwrap_or_else(|_| {
+    format!(
+    "{}/tests/config.yaml",
+    std::env::var("CARGO_MANIFEST_DIR").unwrap()
+    )
+    });
+
+    match load_config(&config_path) {
+    Ok(config) => config.xline_config.endpoints,
+    Err(_) => vec!["127.0.0.1:2379".to_string()], // fallback
+    }
+}
+
+async fn get_store() -> Option<XlineStore> {
+    let endpoints = get_xline_endpoints();
+    let endpoints_str: Vec<&str> = endpoints.iter().map(|s| s.as_str()).collect();
+
+    let xline_store = match XlineStore::new(&endpoints_str).await {
+        Ok(store) => store,
+        Err(_) => {
+            println!("Skipping test - xline not available");
+            return None;
+        }
+    };
+    Some(xline_store)
+}
+
+fn create_test_node(name: &str, cpu: &str, memory: &str) -> Node {
+    let mut capacity = HashMap::new();
+    capacity.insert("cpu".to_string(), cpu.to_string());
+    capacity.insert("memory".to_string(), memory.to_string());
+
+    let mut allocatable = HashMap::new();
+    allocatable.insert("cpu".to_string(), cpu.to_string());
+    allocatable.insert("memory".to_string(), memory.to_string());
+
+    Node {
+        api_version: "v1".to_string(),
+        kind: "Node".to_string(),
+        metadata: ObjectMeta {
+            name: name.to_string(),
+            namespace: "".to_string(),
+            labels: HashMap::new(),
+            annotations: HashMap::new(),
+        },
+        spec: NodeSpec {
+            pod_cidr: "10.244.0.0/24".to_string(),
+        },
+        status: NodeStatus {
+            capacity,
+            allocatable,
+            addresses: vec![
+                NodeAddress {
+                    address_type: "InternalIP".to_string(),
+                    address: "192.168.1.100".to_string(),
+                },
+                NodeAddress {
+                    address_type: "Hostname".to_string(),
+                    address: name.to_string(),
+                },
+            ],
+            conditions: vec![NodeCondition {
+                condition_type: "Ready".to_string(),
+                status: "True".to_string(),
+                last_heartbeat_time: None,
+            }],
+        },
+    }
+}
+
+fn create_test_pod(name: &str, cpu_limit: Option<&str>, memory_limit: Option<&str>) -> PodTask {
+    let resources = if cpu_limit.is_some() || memory_limit.is_some() {
+        Some(ContainerRes {
+            limits: Some(Resource {
+                cpu: cpu_limit.map(|s| s.to_string()),
+                memory: memory_limit.map(|s| s.to_string()),
+            }),
+        })
+    } else {
+        None
+    };
+
+    PodTask {
+        api_version: "v1".to_string(),
+        kind: "Pod".to_string(),
+        metadata: ObjectMeta {
+            name: name.to_string(),
+            namespace: "default".to_string(),
+            labels: HashMap::new(),
+            annotations: HashMap::new(),
+        },
+        spec: PodSpec {
+            nodename: None,
+            containers: vec![ContainerSpec {
+                name: "app".to_string(),
+                image: "nginx:latest".to_string(),
+                ports: vec![],
+                args: vec![],
+                resources,
+            }],
+            init_containers: vec![],
+        },
+    }
+}
+
+async fn run_scheduler(xline_store: Arc<XlineStore>) -> Result<()> {
+    let endpoints = get_xline_endpoints();
+    let endpoints_str: Vec<&str> = endpoints.iter().map(|s| s.as_str()).collect();
+
+    // Create and run the actual Scheduler
+    let scoring_strategy = ScoringStrategy::LeastAllocated;
+    let plugins = Plugins::default();
+
+    let scheduler =
+        Scheduler::try_new(&endpoints_str, xline_store.clone(), scoring_strategy, plugins).await?;
+
+    // Start the scheduler in the background
+    scheduler.run().await;
+
+    Ok(())
+}
+
+async fn cleanup() -> Result<()> {
+    let store = get_store().await;
+    if store.is_none() {
+        return Ok(());
+    }
+    let store = store.unwrap();
+
+    // Clean up all pods and nodes
+    let pod_names = store.list_pods().await?;
+    for pod_name in pod_names {
+        if pod_name.contains("scheduler-test") {
+            store.delete_pod(&pod_name).await?;
+        }
+    }
+
+    let node_names = store.list_nodes().await?;
+    for (node_name, _) in node_names {
+        if node_name.contains("scheduler-test") {
+            store.delete_node(&node_name).await?;
+        }
+    }
+
+    Ok(())
+}
+
+#[tokio::test]
+#[serial]
+async fn test_scheduler_creation_with_xline() {
+    let xline_store = get_store().await;
+    if xline_store.is_none() {
+        return;
+    }
+    let xline_store = xline_store.unwrap();
+    let endpoints = get_xline_endpoints();
+    let endpoints_str: Vec<&str> = endpoints.iter().map(|s| s.as_str()).collect();
+    let scoring_strategy = ScoringStrategy::LeastAllocated;
+    let plugins = Plugins::default();
+
+    let result = Scheduler::try_new(
+        &endpoints_str,
+        Arc::new(xline_store),
+        scoring_strategy,
+        plugins,
+    )
+    .await;
+
+    assert!(
+        result.is_ok(),
+        "Failed to create scheduler: {:?}",
+        result.err()
+    );
+}
+
+#[tokio::test]
+#[serial]
+async fn test_pod_assignment_one() -> Result<()> {
+    let store = get_store().await;
+    if store.is_none() {
+        return Ok(());
+    }
+    let store = Arc::new(store.unwrap());
+
+    run_scheduler(store.clone()).await?;
+
+    // add an dummy node
+    let node_name = "scheduler-test-node";
+    let node = create_test_node(node_name, "4", "4Gi");
+    store
+        .insert_node_yaml(node_name, &serde_yaml::to_string(&node).unwrap())
+        .await
+        .expect("Insert node yaml failed");
+
+    // Create a PodTask with proper structure for the scheduler
+    let pod_name = "scheduler-test-pod";
+    let pod_task = create_test_pod(pod_name, Some("1"), Some("1Gi"));
+
+    let initial_pod_yaml = serde_yaml::to_string(&pod_task).expect("Failed to serialize pod");
+
+    // Insert initial pod without node assignment
+    store
+        .insert_pod_yaml(pod_name, &initial_pod_yaml)
+        .await
+        .expect("Insert pod yaml failed");
+
+    // Wait a bit for the scheduler to potentially process the pod
+    tokio::time::sleep(tokio::time::Duration::from_secs(5)).await;
+
+    // Check if the pod was assigned to a node
+    let final_pod_yaml = store
+        .get_pod_yaml(pod_name)
+        .await
+        .expect("Get final pod yaml failed");
+
+    if let Some(yaml) = final_pod_yaml {
+        let final_pod = serde_yaml::from_str::<PodTask>(&yaml)?;
+        assert!(final_pod.spec.nodename.is_some());
+    }
+
+    // Clean up
+    cleanup().await?;
+    Ok(())
+}
+
+#[tokio::test]
+#[serial]
+async fn test_xline_pod_assignment_multiply() -> Result<()> {
+    let store = get_store().await;
+    if store.is_none() {
+        return Ok(());
+    }
+    let store = Arc::new(store.unwrap());
+
+    run_scheduler(store.clone()).await?;
+
+    // add an dummy node
+    let node_name = "scheduler-test-node";
+    let node = create_test_node(node_name, "4", "4Gi");
+    store
+        .insert_node_yaml(node_name, &serde_yaml::to_string(&node).unwrap())
+        .await
+        .expect("Insert node yaml failed");
+
+    // Create a PodTask with proper structure for the scheduler
+    let pod_names = vec![
+        "scheduler-test-pod-1",
+        "scheduler-test-pod-2",
+        "scheduler-test-pod-3",
+    ];
+
+    for pod_name in &pod_names {
+        let pod_task = create_test_pod(pod_name, Some("1"), Some("1Gi"));
+        let initial_pod_yaml = serde_yaml::to_string(&pod_task).expect("Failed to serialize pod");
+        store
+            .insert_pod_yaml(pod_name, &initial_pod_yaml)
+            .await
+            .expect("Insert pod yaml failed");
+    }
+
+    // Insert initial pod without node assignment
+    for pod_name in &pod_names {
+        // Wait a bit for the scheduler to potentially process the pod
+        tokio::time::sleep(tokio::time::Duration::from_secs(3)).await;
+
+        // Check if the pod was assigned to a node
+        let final_pod_yaml = store
+            .get_pod_yaml(pod_name)
+            .await
+            .expect("Get final pod yaml failed");
+
+        if let Some(yaml) = final_pod_yaml {
+            let final_pod = serde_yaml::from_str::<PodTask>(&yaml)?;
+            assert!(final_pod.spec.nodename.is_some());
+        }
+    }
+    cleanup().await?;
+    Ok(())
+}
+
+#[tokio::test]
+#[serial]
+async fn test_no_pod_assignment_when_no_nodes() -> Result<()> {
+    cleanup().await?;
+    tokio::time::sleep(tokio::time::Duration::from_secs(5)).await;
+    let store = get_store().await;
+    if store.is_none() {
+        return Ok(());
+    }
+    let store = Arc::new(store.unwrap());
+
+    run_scheduler(store.clone()).await?;
+
+    // Create a PodTask with proper structure for the scheduler
+    let pod_name = "scheduler-test-pod-no-nodes";
+    let pod_task = create_test_pod(pod_name, Some("1"), Some("1Gi"));
+
+    let initial_pod_yaml = serde_yaml::to_string(&pod_task).expect("Failed to serialize pod");
+
+    // Insert initial pod without node assignment
+    store
+        .insert_pod_yaml(pod_name, &initial_pod_yaml)
+        .await
+        .expect("Insert pod yaml failed");
+
+    // Wait a bit for the scheduler to potentially process the pod
+    tokio::time::sleep(tokio::time::Duration::from_secs(5)).await;
+
+    // Check if the pod was assigned to a node
+    let final_pod_yaml = store
+        .get_pod_yaml(pod_name)
+        .await
+        .expect("Get final pod yaml failed");
+
+    if let Some(yaml) = final_pod_yaml {
+        let final_pod = serde_yaml::from_str::<PodTask>(&yaml)?;
+        assert!(final_pod.spec.nodename.is_none());
+    }
+
+    // Clean up
+    cleanup().await?;
+    Ok(())
+}

--- a/third-party/Cargo.toml
+++ b/third-party/Cargo.toml
@@ -16,7 +16,7 @@ path = "top/main.rs"
 # and all options Cargo supports.
 [dependencies]
 anyhow = "1.0.98"
-async-fs = { version = "2.1.1"}
+async-fs = { version = "2.1.1" }
 async-std = "1.12"
 async-trait = "0.1.86"
 async-global-executor = { version = "2.4.1" }
@@ -31,8 +31,8 @@ bincode = "1.3.3"
 bytes = "1.10.1"
 caps = "0.5.5"
 chrono = { version = "0.4", default-features = false, features = [
-    "clock",
-    "serde",
+  "clock",
+  "serde",
 ] }
 clap = { version = "4.5.32", features = ["derive"] }
 cni-plugin = { version = "0.2.1", features = ["with-smol"] }
@@ -64,18 +64,18 @@ native-tls = "0.2.14"
 nc = "0.9.5"
 netlink-packet-route = "0.22.0"
 nix = { version = "0.29.0", features = [
-    "signal",
-    "user",
-    "fs",
-    "socket",
-    "sched",
-    "mount",
-    "mman",
-    "resource",
-    "dir",
-    "term",
-    "hostname",
-    "process",
+  "signal",
+  "user",
+  "fs",
+  "socket",
+  "sched",
+  "mount",
+  "mman",
+  "resource",
+  "dir",
+  "term",
+  "hostname",
+  "process",
 ] }
 oci-spec = { version = "~0.7.1", features = ["runtime"] }
 once_cell = "1.21.2"
@@ -90,22 +90,23 @@ radix_trie = "0.2.1"
 rand = "0.9.0"
 rbpf = { version = "0.3.0", optional = true }
 regex = { version = "1.10.6", default-features = false, features = [
-    "std",
-    "unicode-perl",
+  "std",
+  "unicode-perl",
 ] }
 reqwest = { version = "0.12.7", features = ["json", "blocking"] }
 rcgen = "0.12.1"
 rfuse3 = { version = "0.0.3", features = ["tokio-runtime", "unprivileged"] }
-rtnetlink =  "0.16.0"
+rtnetlink = "0.16.0"
 rust-criu = "0.4.0"
 rust-cni = "0.1.2"
-rustls = "0.23" 
+rustls = "0.23"
 safe-path = "0.1.0"
 semver = "0.11.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.138"
 serde_with = "3"
 serde_yaml = "0.9"
+serial_test = "3.2.0"
 sha2 = "0.10.8"
 sha256 = "1.6.0"
 slab = "0.4.9"
@@ -120,9 +121,9 @@ tracing-journald = "0.3.1"
 tracing-subscriber = { version = "0.3.19", features = ["json", "env-filter"] }
 trait-make = "0.1"
 uuid = { version = "1.15.1", features = [
-    "v4",
-    "fast-rng",
-    "macro-diagnostics",
+  "v4",
+  "fast-rng",
+  "macro-diagnostics",
 ] }
 vm-memory = "0.16.1"
 vmm-sys-util = "0.12.1"

--- a/third-party/fixups/scc/fixups.toml
+++ b/third-party/fixups/scc/fixups.toml
@@ -1,0 +1,1 @@
+extra_srcs = ["README.md", "md_doc/**"]

--- a/third-party/fixups/sdd/fixups.toml
+++ b/third-party/fixups/sdd/fixups.toml
@@ -1,0 +1,1 @@
+extra_srcs = ["README.md", "md_doc/**"]


### PR DESCRIPTION
### 集成 libscheduler 到 rks 

将调度器库(libscheduler)集成到rks中，实现Pod的自动节点调度功能。

 ### 主要更改

 - 新增调度器集成：在 rks/src/scheduler.rs 中实现了 Scheduler 结构体，负责处理Pod的节点分配
 - 调度逻辑：运行调度器时新建一个后台任务，持续不断地通过libscheduler提供的channel接收调度结果，并向xline store中更新Pod配置中的 nodename 字段
 - 构建配置：更新了BUCK和Cargo.toml文件，添加libscheduler依赖
 - 主程序集成：在 main.rs 中初始化并运行调度器